### PR TITLE
Correctly set max_sets, max_workouts in the query string

### DIFF
--- a/fitocracy_export/__init__.py
+++ b/fitocracy_export/__init__.py
@@ -71,8 +71,7 @@ class APISession(object):
         
     def _get_activity_data_by_id(self, id):
         
-        response = self.opener.open("http://fitocracy.com/get_history_json_from_activity/{0}/".format(id), 
-            b'max_sets=-1&max_workouts=-1&reverse=1')
+        response = self.opener.open("http://fitocracy.com/get_history_json_from_activity/{0}/?max_sets=-1&max_workouts=-1&reverse=1".format(id))
 
         if not self.activity_data:
             self.activity_data = {}


### PR DESCRIPTION
Adds a missing '?' into the query string.

max_sets & max_workouts filters were incorrectly set in the query
string, resulting in truncated query results.  Usually this resulted
in only getting the most recent 31 activities from Fitocracy.

More details in https://github.com/sjoconnor/fitocracy-api/issues/5

See here for directory listing of before & after the fix, see how the output JSON file size grows with my fix:

```
nurpax@nurpax:~/dev/fitocracy-export$ ls -la *fix*.json
-rw-r--r-- 1 nurpax nurpax 2709426 Jan 15 00:57 after_fix.json
-rw-r--r-- 1 nurpax nurpax 1138640 Jan 15 00:53 before_fix.json
```

Also run my WIP import script on the output and now I can finally see my deadlift results from the summer. :)
